### PR TITLE
Fix displayed amount upon performing a "delegate" operation

### DIFF
--- a/libs/coin-modules/coin-elrond/src/buildOptimisticOperation.test.ts
+++ b/libs/coin-modules/coin-elrond/src/buildOptimisticOperation.test.ts
@@ -1,0 +1,89 @@
+import { Account } from "@ledgerhq/types-live";
+import BigNumber from "bignumber.js";
+import { buildOptimisticOperation } from "./buildOptimisticOperation";
+import { ElrondProtocolTransaction, Transaction } from "./types";
+
+describe("buildOptimisticOperation", () => {
+  it("should work with mode = send", async () => {
+    const account = {
+      freshAddress: "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+    } as Account;
+
+    const transaction = {
+      family: "elrond",
+      mode: "send",
+      fees: new BigNumber("1"),
+      amount: new BigNumber("42"),
+      recipient: "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+    } as Transaction;
+
+    const notSignedTransaction: ElrondProtocolTransaction = {
+      nonce: 7,
+    } as ElrondProtocolTransaction;
+
+    const operation = buildOptimisticOperation(account, transaction, notSignedTransaction);
+
+    expect(operation.type).toEqual("OUT");
+    expect(operation.value).toEqual(new BigNumber("43"));
+    expect(operation.fee).toEqual(new BigNumber("1"));
+    expect(operation.extra).toEqual({
+      amount: new BigNumber("0"),
+    });
+  });
+
+  it("should work with mode = delegate", async () => {
+    const account = {
+      freshAddress: "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+    } as Account;
+
+    const transaction = {
+      family: "elrond",
+      mode: "delegate",
+      fees: new BigNumber("1"),
+      amount: new BigNumber("42"),
+      recipient: "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqppllllls9ftvxy",
+      data: "delegate",
+    } as Transaction;
+
+    const notSignedTransaction: ElrondProtocolTransaction = {
+      nonce: 7,
+    } as ElrondProtocolTransaction;
+
+    const operation = buildOptimisticOperation(account, transaction, notSignedTransaction);
+
+    expect(operation.type).toEqual("DELEGATE");
+    expect(operation.value).toEqual(new BigNumber("43"));
+    expect(operation.fee).toEqual(new BigNumber("1"));
+    expect(operation.extra).toEqual({
+      amount: new BigNumber("42"),
+    });
+  });
+
+  it("should work with mode = claimRewards", async () => {
+    const account = {
+      freshAddress: "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+    } as Account;
+
+    const transaction = {
+      family: "elrond",
+      mode: "claimRewards",
+      fees: new BigNumber("1"),
+      amount: new BigNumber("42"),
+      recipient: "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqppllllls9ftvxy",
+      data: "claimRewards",
+    } as Transaction;
+
+    const notSignedTransaction: ElrondProtocolTransaction = {
+      nonce: 7,
+    } as ElrondProtocolTransaction;
+
+    const operation = buildOptimisticOperation(account, transaction, notSignedTransaction);
+
+    expect(operation.type).toEqual("REWARD");
+    expect(operation.value).toEqual(new BigNumber("1"));
+    expect(operation.fee).toEqual(new BigNumber("1"));
+    expect(operation.extra).toEqual({
+      amount: new BigNumber("0"),
+    });
+  });
+});

--- a/libs/coin-modules/coin-elrond/src/buildOptimisticOperation.ts
+++ b/libs/coin-modules/coin-elrond/src/buildOptimisticOperation.ts
@@ -65,7 +65,7 @@ export const buildOptimisticOperation = (
     null;
 
   const value =
-    tokenAccount || transaction.mode !== "send"
+    tokenAccount || (transaction.mode !== "send" && transaction.mode != "delegate")
       ? fees
       : transaction.amount.plus(transaction.fees || new BigNumber(0));
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fixed the displayed output amount for delegation operations - previously, the transaction fee is displayed. Now, it's the fee plus the delegated amount.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
